### PR TITLE
Add regression tests and clean removal messaging in CLI

### DIFF
--- a/hex3_taboo.py
+++ b/hex3_taboo.py
@@ -195,8 +195,7 @@ class Hex3TabooGame:
         elif action == "remove":
             if len(parts) != 1:
                 raise ValueError("Usage: remove")
-            removed = self.remove_last_opponent_stone()
-            print(f"Removed opponent stone at {removed}.")
+            self.remove_last_opponent_stone()
         else:
             raise ValueError("Unknown command. Use 'place q r' or 'remove'.")
 
@@ -231,10 +230,16 @@ def main() -> None:
             print("\nGame aborted.")
             break
         try:
+            acting_player = game.current_player
             result = game.take_turn(command)
         except Exception as exc:  # broad for CLI feedback
             print(f"Error: {exc}")
             continue
+        else:
+            if game.history and game.history[-1].action == "remove" and game.history[-1].player == acting_player:
+                coord = game.history[-1].coordinate
+                if coord is not None:
+                    print(f"Removed opponent stone at {coord}.")
         if result:
             print(game.board.render())
             print(result)

--- a/tests/test_hex3_taboo.py
+++ b/tests/test_hex3_taboo.py
@@ -1,0 +1,92 @@
+import unittest
+
+from hex3_taboo import Hex3TabooGame, HexBoard
+
+
+class HexBoardTests(unittest.TestCase):
+    def test_generate_coordinates_count(self):
+        board = HexBoard(radius=4)
+        # Known formula for number of cells in hex board of radius r: 1 + 3r(r+1)
+        expected_cells = 1 + 3 * 4 * 5
+        self.assertEqual(len(board.cells), expected_cells)
+
+    def test_is_valid_and_get_set(self):
+        board = HexBoard(radius=2)
+        coord = (0, 0)
+        self.assertTrue(board.is_valid(coord))
+        self.assertIsNone(board.get(coord))
+        board.set(coord, 1)
+        self.assertEqual(board.get(coord), 1)
+        with self.assertRaises(ValueError):
+            board.get((5, 5))
+        with self.assertRaises(ValueError):
+            board.set((5, 5), None)
+
+
+class Hex3TabooGameTests(unittest.TestCase):
+    def test_loss_on_isolated_three(self):
+        game = Hex3TabooGame(radius=3)
+        # Sequence creates a vertical line of exactly three stones for player 1
+        commands = [
+            "place 0 0",
+            "place 1 -1",
+            "place 0 1",
+            "place 1 0",
+            "place 0 -1",
+        ]
+        result = None
+        for command in commands:
+            result = game.take_turn(command)
+        self.assertIsNotNone(result)
+        self.assertIn("loses", result)
+        self.assertEqual(game.current_player, 1)
+
+    def test_win_on_four_in_a_row(self):
+        game = Hex3TabooGame(radius=3)
+        commands = [
+            "place 0 0",
+            "place 2 -1",
+            "place 0 1",
+            "place 2 0",
+            "place 0 -1",
+            "place 2 1",
+            "place 0 -2",
+        ]
+        result = None
+        for command in commands:
+            result = game.take_turn(command)
+        self.assertIsNotNone(result)
+        self.assertIn("wins", result)
+        self.assertEqual(game.current_player, 1)
+
+    def test_second_player_can_remove_only_once(self):
+        game = Hex3TabooGame(radius=2)
+        game.take_turn("place 0 0")  # player 1
+        game.take_turn("place 1 0")  # player 2
+        game.take_turn("place -1 0")  # player 1
+        # Player 2 can remove the last move (player 1's stone)
+        result = game.take_turn("remove")
+        self.assertIsNone(result)
+        self.assertIsNone(game.board.get((-1, 0)))
+        # Back to player 2 after an additional move
+        game.take_turn("place 0 1")  # player 1 places, no immediate loss
+        with self.assertRaises(ValueError):
+            game.take_turn("remove")  # player 2 already spent the removal
+
+    def test_can_remove_conditions(self):
+        game = Hex3TabooGame(radius=2)
+        self.assertFalse(game.can_remove())  # player 1's turn
+        game.take_turn("place 0 0")  # player 1
+        self.assertTrue(game.can_remove())   # player 2 may remove immediately
+        game.take_turn("place 1 0")  # player 2 opts to place instead
+        self.assertFalse(game.can_remove())  # player 1 cannot remove
+        game.take_turn("place -1 0")  # player 1
+        self.assertTrue(game.can_remove())   # player 2 can remove once more
+        game.take_turn("remove")
+        self.assertFalse(game.can_remove())  # player 1 turn
+        game.take_turn("place 0 1")  # player 1
+        self.assertFalse(game.can_remove())  # player 2 already used the removal
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for board coordinate generation, win/loss detection, and removal rules
- silence the game engine during removals and print the notification from the CLI loop instead

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68e3af47550c83319598e0fffb1d6be6