### PR TITLE
Add Tkinter GUI interface for Hex 3-Taboo

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,19 @@ Designing a PC version requires translating the tactile board into an intuitive,
 - **Cross‑platform support**: Extend to mobile (iOS/Android) and browser with shared codebase.
 - **Spectator mode and replay system**: Allow others to watch games live or review completed games with move-by-move playback.
 - **Community content**: Enable users to create custom boards, themes, and rule sets.
+
+## Running the prototype
+
+Install Python 3.8+ with Tkinter. To play from the command line:
+
+```bash
+python hex3_taboo.py --mode cli
+```
+
+To launch the GUI version instead (requires Tkinter):
+
+```bash
+python hex3_taboo.py --mode gui
+```
+
+You can adjust the board radius in either mode with `--radius` (default 4).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a Tkinter-powered GUI that renders the hex board and supports placing stones or using the removal action
- refactor the script entry point into CLI/GUI runners with argparse flags while gracefully handling missing Tkinter installs
- document how to launch each mode and ensure pytest can import the module reliably

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b2facce483318bba959c33b23cc6