### PR TITLE
Switch removal action to neutralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 1. Players alternate turns; no passes are allowed.
 2. **Placement**: On their turn a player must either:
    - **Place** one stone of their color on any empty cell.
-   - **Remove (once per game, for the second player only)**: The second player may once per game, instead of placing a stone, remove the opponent’s last placed stone. Removing concludes the turn and cannot be used to negate a win already recorded.
+   - **Neutralize (once per game, for the second player only)**: The second player may once per game, instead of placing a stone, neutralize the opponent’s last placed stone. The target stone remains on the board but becomes neutral (belongs to neither player). Neutralizing concludes the turn and cannot be used to negate a win already recorded.
 3. **Evaluation order** (at the end of each turn):
-   - **Victory**: If the just‑placed player (or the player whose removal ended the turn) has at least one straight line of four or more consecutive stones of their color, they win immediately.
+  - **Victory**: If the just‑placed player (or the player whose neutralization ended the turn) has at least one straight line of four or more consecutive stones of their color, they win immediately.
    - **Loss**: If they have no winning line but have one or more straight lines that are exactly three stones long (neither shorter nor longer), they lose immediately.
    - If neither condition is met, play continues. If the board fills without a win/loss, the game is a draw.
 4. **Equal outcomes**: If a turn simultaneously produces a winning line and an exactly three‑stone line, the win takes precedence.
@@ -24,14 +24,14 @@
 ### Additional match rules
 
 - **Time control**: For online play or tournaments, configurable timers (e.g., 10 min per player with a 10 second increment) ensure fairness.
-- **Scoring series**: In match play the first player can be alternated or balanced via series; track wins, losses, draws and second‑player advantages (the removal ability only applies to the second player in each game).
+- **Scoring series**: In match play the first player can be alternated or balanced via series; track wins, losses, draws and second‑player advantages (the neutralization ability only applies to the second player in each game).
 
 ## 2. Digital adaptation goals
 
 Designing a PC version requires translating the tactile board into an intuitive, responsive digital experience. Modern digital board games provide automated rule enforcement, tutorials, and online multiplayer. Our goals for the PC adaptation are:
 
 1. **Ease of learning**  
-   - Integrate an interactive tutorial that demonstrates placement, removal, and the win/lose conditions. Digital board games benefit from built‑in lessons and visual aids.  
+   - Integrate an interactive tutorial that demonstrates placement, neutralization, and the win/lose conditions. Digital board games benefit from built‑in lessons and visual aids.
    - Provide tooltips and optional hints that highlight potential 3‑in‑a‑row risks and 4‑in‑a‑row opportunities.  
    - Offer rule summaries and glossary accessible at any time.
 
@@ -42,7 +42,7 @@ Designing a PC version requires translating the tactile board into an intuitive,
 3. **User interface**  
    - **Board rendering**: Implement a clean 2D top‑down view of the hex grid with subtle shading and coordinates. When a player hovers over a cell, highlight potential placement.  
    - **Line highlighting**: When a line of two or more consecutive stones is created, highlight it briefly; highlight winning lines distinctly and mark exactly three‑stone lines with warning colors or rings.  
-   - **Removal indicator**: Show a “remove” button for the second player until it is used; on click, highlight only the opponent’s most recent stone as removable.  
+   - **Neutralization indicator**: Show a “neutralize” button for the second player until it is used; on click, highlight only the opponent’s most recent stone as eligible.
    - **Accessibility**: Provide color‑blind friendly palettes and adjustable size/zoom.
 
 4. **Modes of play**  
@@ -65,7 +65,7 @@ Designing a PC version requires translating the tactile board into an intuitive,
 - **Core game engine**  
   - Maintain the board state in a two‑dimensional axial coordinate array.  
   - Implement algorithms to detect straight lines along three axes quickly after each move; scan outward from the new stone to count consecutive stones and determine whether a line is exactly three or four or more.  
-  - Encapsulate rules (turn order, removal, win/loss detection) in a single authoritative game state class.  
+  - Encapsulate rules (turn order, neutralization, win/loss detection) in a single authoritative game state class.
   - Provide a history stack to enable undo/redo.
 
 - **User interface layer**  
@@ -79,11 +79,11 @@ Designing a PC version requires translating the tactile board into an intuitive,
   - Persist match results in a server database for leaderboards.
 
 - **Artificial intelligence**  
-  - Start with simple heuristics: maximize own potential connections, block opponent’s threats, use removal ability strategically.  
+  - Start with simple heuristics: maximize own potential connections, block opponent’s threats, use the neutralization ability strategically.
   - Optionally implement Monte Carlo Tree Search (MCTS) or minimax with alpha‑beta pruning for stronger AI.
 
 - **Tutorial scripting**  
-  - Design a sequence of scripted steps demonstrating placement, losing with three in a row, winning with four, and using the removal ability.  
+  - Design a sequence of scripted steps demonstrating placement, losing with three in a row, winning with four, and using the neutralization ability.
   - Use overlay text, arrows, and interactive prompts to guide players through each mechanic.
 
 ## 4. Development roadmap
@@ -95,7 +95,7 @@ Designing a PC version requires translating the tactile board into an intuitive,
 
 2. **Core engine implementation (Weeks 3‑4)**  
    - Implement board data structure and turn logic.  
-   - Implement win/loss detection and removal mechanic.  
+   - Implement win/loss detection and the neutralization mechanic.
    - Build a simple command‑line prototype for testing rules.
 
 3. **User interface (Weeks 5‑7)**  
@@ -125,7 +125,7 @@ Designing a PC version requires translating the tactile board into an intuitive,
 
 ## 5. Future enhancements
 
-- **Variant rules**: Option to adjust board size, change removal mechanic to other balancing schemes (e.g., swap or double move), or introduce additional stones with special effects.
+- **Variant rules**: Option to adjust board size, change the neutralization mechanic to other balancing schemes (e.g., swap or double move), or introduce additional stones with special effects.
 - **Cross‑platform support**: Extend to mobile (iOS/Android) and browser with shared codebase.
 - **Spectator mode and replay system**: Allow others to watch games live or review completed games with move-by-move playback.
 - **Community content**: Enable users to create custom boards, themes, and rule sets.

--- a/tests/test_hex3_taboo.py
+++ b/tests/test_hex3_taboo.py
@@ -68,10 +68,10 @@ class Hex3TabooGameTests(unittest.TestCase):
         game.take_turn("place 0 0")  # player 1
         game.take_turn("place 1 0")  # player 2
         game.take_turn("place -1 0")  # player 1
-        # Player 2 can remove the last move (player 1's stone)
+        # Player 2 can neutralize the last move (player 1's stone)
         result = game.take_turn("remove")
         self.assertIsNone(result)
-        self.assertIsNone(game.board.get((-1, 0)))
+        self.assertEqual(game.board.get((-1, 0)), HexBoard.DISABLED_STONE)
         # Back to player 2 after an additional move
         game.take_turn("place 0 1")  # player 1 places, no immediate loss
         with self.assertRaises(ValueError):
@@ -94,14 +94,14 @@ class Hex3TabooGameTests(unittest.TestCase):
     def test_removed_cell_cannot_be_reclaimed_immediately(self):
         game = Hex3TabooGame(radius=2)
         game.take_turn("place 0 0")  # player 1
-        game.take_turn("remove")      # player 2 removes the stone at (0, 0)
+        game.take_turn("remove")      # player 2 neutralizes the stone at (0, 0)
         with self.assertRaises(ValueError):
             game.take_turn("place 0 0")  # player 1 cannot reuse the same cell immediately
         # Player 1 may place elsewhere, which clears the restriction.
         game.take_turn("place 1 0")
         self.assertEqual(game.board.get((1, 0)), 1)
         # Now it's player 2's turn, and the previously removed cell remains empty.
-        self.assertIsNone(game.board.get((0, 0)))
+        self.assertEqual(game.board.get((0, 0)), HexBoard.DISABLED_STONE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the rulebook to describe the second player's neutralization action instead of removal
- change the removal mechanic to neutralize the opponent's last stone, introducing a disabled state and updating UI/CLI messaging
- adjust tests to cover the neutralized stone state

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e3bcaf43a88331bcf0516bb79f2ab1